### PR TITLE
416 is 'Range Not Satisfiable' not 'Requested Range Not Satisfiable'

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The module ships with the following HttpErrors:
 * 413 RequestEntityTooLargeError
 * 414 RequesturiTooLargeError
 * 415 UnsupportedMediaTypeError
-* 416 RequestedRangeNotSatisfiableError
+* 416 RangeNotSatisfiableError (For Node >= 4 & iojs >= 3)
+* 416 RequestedRangeNotSatisfiableError (For Node 0.x & iojs < 3)
 * 417 ExpectationFailedError
 * 418 ImATeapotError
 * 422 UnprocessableEntityError

--- a/lib/httpErrors.js
+++ b/lib/httpErrors.js
@@ -29,7 +29,8 @@ var HttpError = require('./baseClasses/HttpError');
 // RequestEntityTooLargeError
 // RequesturiTooLargeError
 // UnsupportedMediaTypeError
-// RequestedRangeNotSatisfiableError
+// RangeNotSatisfiableError (For Node >= 4 & iojs >= 3)
+// RequestedRangeNotSatisfiableError (For Node 0.x & iojs < 3)
 // ExpectationFailedError
 // ImATeapotError
 // UnprocessableEntityError


### PR DESCRIPTION
As per spec (https://tools.ietf.org/html/rfc7233#page-15) and so in [http.STATUS_CODES](https://github.com/nodejs/node/blob/master/lib/_http_server.js#L56), the prop name is `RangeNotSatisfiableError`, not `RequestedRangeNotSatisfiableError`