### PR TITLE
options constructor accepts a context object

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 4.0.0 (wip)
 
+- NEW: Error constructor now takes `options.context`, which is a bucket of
+  random properties that are saved to the Error object
 - NEW: All Errors now have `toString()` and `toJSON()` methods
 - BREAKING: `code` and `restCode` properties were normalized across all
   classes. `code` property now has a value of 'Error' for HttpError and

--- a/README.md
+++ b/README.md
@@ -290,6 +290,8 @@ Or pass in an options object for more customization:
 by restify to render an error when it is directly passed to `res.send()`. By
 default, it is the name of your error constructor (e.g., the restCode for a
 BadDigestError is BadDigest).
+* `options.context` {Object} - object of contextual properties relevant to the
+creation of the error, i.e., the url of a failed http request
 
 In all signatures, you can optionally pass in an Error as the first argument,
 which will cause WError to use it as a prior cause:

--- a/lib/baseClasses/HttpError.js
+++ b/lib/baseClasses/HttpError.js
@@ -89,6 +89,14 @@ function HttpError() {
         code: options.code || self.code,
         message: self.message || ''
     };
+
+    /**
+     * an object of random properties that may be added to the object upon
+     * instantion. useful for capturing context around a specific error.
+     * @property
+     * @type     {Object}
+     */
+    self.context = options.context || null;
 }
 util.inherits(HttpError, WError);
 

--- a/test/index.js
+++ b/test/index.js
@@ -43,7 +43,11 @@ describe('restify-errors node module.', function() {
             var options = {
                 message: 'my http error',
                 statusCode: 799,
-                code: 'myhttp'
+                code: 'myhttp',
+                context: {
+                    foo: 'bar',
+                    baz: [1,2,3]
+                }
             };
             var myErr = new HttpError(options);
 
@@ -55,6 +59,8 @@ describe('restify-errors node module.', function() {
             assert.isObject(myErr.body);
             assert.equal(myErr.body.message, options.message);
             assert.equal(myErr.body.code, 'myhttp');
+            assert.equal(myErr.context.foo, 'bar');
+            assert.deepEqual(myErr.context.baz, [1,2,3]);
         });
 
         it('should create HttpError, and retain a prior cause', function() {
@@ -118,7 +124,11 @@ describe('restify-errors node module.', function() {
             var myErr = new httpErrors.BadGatewayError({
                 message: msg,
                 statusCode: 799,  // can pass in any crazy status code
-                code: 'myhttp'
+                code: 'myhttp',
+                context: {
+                    foo: 'bar',
+                    baz: [1,2,3]
+                }
             });
 
             assert.equal(myErr.name, 'BadGatewayError');
@@ -128,6 +138,8 @@ describe('restify-errors node module.', function() {
             assert.isObject(myErr.body);
             assert.equal(myErr.body.message, msg);
             assert.equal(myErr.body.code, 'myhttp');
+            assert.equal(myErr.context.foo, 'bar');
+            assert.deepEqual(myErr.context.baz, [1,2,3]);
         });
 
         it('should create BadGatewayError, and retain a prior cause', function() {
@@ -183,7 +195,11 @@ describe('restify-errors node module.', function() {
         it('should create RestError, using options object', function() {
             var options = {
                 message: 'my http error',
-                statusCode: 799
+                statusCode: 799,
+                context: {
+                    foo: 'bar',
+                    baz: [1,2,3]
+                }
             };
             var myErr = new RestError(options);
 
@@ -195,6 +211,8 @@ describe('restify-errors node module.', function() {
             assert.isObject(myErr.body);
             assert.equal(myErr.body.message, options.message);
             assert.equal(myErr.body.code, 'Error');
+            assert.equal(myErr.context.foo, 'bar');
+            assert.deepEqual(myErr.context.baz, [1,2,3]);
         });
 
         it('should create RestError, and retain a prior cause', function() {
@@ -258,7 +276,11 @@ describe('restify-errors node module.', function() {
             var options = {
                 message: 'my http error',
                 restCode: 'yay',
-                statusCode: 799
+                statusCode: 799,
+                context: {
+                    foo: 'bar',
+                    baz: [1,2,3]
+                }
             };
             var myErr = new restErrors.BadDigestError(options);
 
@@ -270,6 +292,8 @@ describe('restify-errors node module.', function() {
             assert.isObject(myErr.body);
             assert.equal(myErr.body.message, options.message);
             assert.equal(myErr.body.code, 'yay');
+            assert.equal(myErr.context.foo, 'bar');
+            assert.deepEqual(myErr.context.baz, [1,2,3]);
         });
 
         it('should create BadDigestError, args should fall through to WError', function() {
@@ -504,12 +528,15 @@ describe('restify-errors node module.', function() {
         });
 
         it('should create custom error using makeConstructor', function() {
-            var underlyingErr = new Error('underlying error!');
             restifyErrors.makeConstructor('ExecutionError', {
                 statusCode: 406,
                 failureType: 'motion',
                 code: 'moo'
             });
+        });
+
+        it('should create custom error instance', function() {
+            var underlyingErr = new Error('underlying error!');
             var err = new restifyErrors.ExecutionError(underlyingErr, 'bad joystick input');
 
             assert.equal(err instanceof restifyErrors.ExecutionError, true);
@@ -535,14 +562,17 @@ describe('restify-errors node module.', function() {
             assert.equal(err.toString(), 'ExecutionError: bad joystick input');
         });
 
-        it('should create custom error using makeConstructor (with lower case Error name)', function() {
+        it('should create custom error instance using options', function() {
+            var options = {
+                message: 'bad joystick input',
+                statusCode: 799,
+                context: {
+                    foo: 'bar',
+                    baz: [1,2,3]
+                }
+            };
             var underlyingErr = new Error('underlying error!');
-            restifyErrors.makeConstructor('Executionerror', {
-                statusCode: 406,
-                failureType: 'motion',
-                code: 'moo'
-            });
-            var err = new restifyErrors.ExecutionError(underlyingErr, 'bad joystick input');
+            var err = new restifyErrors.ExecutionError(underlyingErr, options);
 
             assert.equal(err instanceof restifyErrors.ExecutionError, true);
             assert.equal(err instanceof RestError, true);
@@ -550,7 +580,7 @@ describe('restify-errors node module.', function() {
             assert.equal(err instanceof WError, true);
             assert.equal(err instanceof Error, true);
             assert.equal(err.message, 'bad joystick input');
-            assert.equal(err.statusCode, 406);
+            assert.equal(err.statusCode, 799);
             assert.equal(err.failureType, 'motion');
             assert.equal(err.restCode, 'Execution');
             assert.equal(err.code, 'moo');
@@ -558,6 +588,8 @@ describe('restify-errors node module.', function() {
             assert.equal(err.body.code, 'Execution');
             assert.equal(err.body.message, 'bad joystick input');
             assert.equal(err.we_cause, underlyingErr);
+            assert.equal(err.context.foo, 'bar');
+            assert.deepEqual(err.context.baz, [1,2,3]);
 
             // assert stringification
             assert.equal(err.toJSON(), JSON.stringify({
@@ -565,6 +597,25 @@ describe('restify-errors node module.', function() {
                 message: 'bad joystick input'
             }));
             assert.equal(err.toString(), 'ExecutionError: bad joystick input');
+        });
+
+        it('should create custom error using makeConstructor (with lower case Error name)', function() {
+            var underlyingErr = new Error('underlying error!');
+            restifyErrors.makeConstructor('Executionerror', {
+                statusCode: 406,
+                failureType: 'motion',
+                code: 'moo'
+            });
+            var err = new restifyErrors.Executionerror(underlyingErr, 'bad joystick input');
+
+            assert.equal(err instanceof restifyErrors.Executionerror, true);
+
+            // assert stringification
+            assert.equal(err.toJSON(), JSON.stringify({
+                code: 'Execution',
+                message: 'bad joystick input'
+            }));
+            assert.equal(err.toString(), 'Executionerror: bad joystick input');
         });
 
         it('should throw when creating a constructor that already exists', function() {


### PR DESCRIPTION
I'm finding I frequently want to add contextual properties to an object I'm creating to store some context about what might have caused that error. i.e., if an http request failed, I might want to put the url on the error object.

Since we already have the options constructor, this seemed like a good place to put it. All arbitrary context properties are stored on the `context` property instead of directly on the error itself.

Suggestions/feedback @yunong @micahr? 