### PR TITLE
add a bunyan serializer for supporting context objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,29 @@ Caused by: Error: file lookup failed!
     at Function.Module.runMain (module.js:501:10)
     at startup (node.js:129:16)
     at node.js:814:3
-
 ```
+
+### Bunyan support
+
+Since errors created via restify-errors inherit from VError, you'll get out of
+the box support via bunyan's standard serializers. If you are using the
+`context` property, you can use the serializer shipped with restify-errors:
+
+```js
+
+var bunyan = require('bunyan');
+var restifyErrors = require('restify-errors');
+
+var log = bunyan.createLogger({
+    name: 'myLogger',
+    serializers: {
+        err: restifyErrors.bunyanSerializer
+    });
+```
+
+You can, of course, combine this with the standard set of serializers that
+bunyan ships with.
+
 
 For more information about building rich errors, check out
 [VError](https://github.com/davepacheco/node-verror).

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,6 +114,77 @@ function makeInstance(constructor, constructorOpt, args) {
 
 
 
+
+/**
+ * built in bunyan serializer for restify errors. it's more or less the
+ * standard bunyan serializer with support for the context property. borrows
+ * liberally from:
+ * https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js
+ * @public
+ * @function serializer
+ * @param {Object} err an error object
+ * @returns {Object} serialized object for bunyan output
+ */
+function serializer(err) {
+
+    if (!err || !err.stack) {
+        return err;
+    }
+
+    function getSerializedContext(ex) {
+
+        var ret = '';
+
+        if (ex.context && _.keys(ex.context).length > -1) {
+            ret += ' (';
+            _.forEach(ex.context, function(val, key) {
+                ret += key + '=' + val.toString() + ', ';
+            });
+            // remove last comma
+            ret = ret.slice(0, -2);
+            ret += ')';
+        }
+
+        return ret + '\n';
+    }
+
+    function getFullErrorStack(ex) {
+        var e = ex;
+        var out = '';
+        var first = true;
+
+        do {
+            if (first !== true) {
+                out += '\nCaused by: ';
+            }
+
+            // parse out first new line of stack trace, append context
+            // there.
+            var stackString = (e.stack || e.toString()).split('\n');
+
+            out += stackString.shift() + getSerializedContext(e);
+            out += stackString.join('\n');
+            e = (e.cause) ? e.cause() : null;
+            first = false;
+        } while (e);
+
+        // remove last new line char
+        out = out.slice(0, -2);
+
+        return out;
+    }
+
+    return {
+        message: err.message,
+        name: err.name,
+        stack: getFullErrorStack(err),
+        code: err.code,
+        signal: err.signal
+    };
+}
+
+
+
 module.exports = _.assign({}, httpErrors, restErrors, {
     // export base classes
     HttpError: HttpError,
@@ -125,6 +196,9 @@ module.exports = _.assign({}, httpErrors, restErrors, {
 
     // deprecated method names, how long do we keep these for?
     // restify has already been updated, but what about external consumers?
-    codeToHttpError: makeErrFromCode
+    codeToHttpError: makeErrFromCode,
+
+    // built in bunyan serializer
+    bunyanSerializer: serializer
 });
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test": "make test"
   },
   "devDependencies": {
+    "bunyan": "^1.5.1",
     "chai": "^3.4.1",
     "coveralls": "^2.11.4",
     "eslint": "^1.9.0",


### PR DESCRIPTION
FYI @yunong @micahr supports the new context objects. Might look something like:

```
[2016-02-08T23:24:09.291Z] ERROR: unit-test/49005 on lgml-aliu: wrapped error (err.code=InternalServer)
    InternalServerError: ISE (foo=bar, baz=1)
        at Context.<anonymous> (/Users/aliu/Sandbox/npm/restify-errors/test/index.js:743:25)
        at callFnAsync (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runnable.js:306:8)
        at Test.Runnable.run (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runnable.js:261:7)
        at Runner.runTest (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:421:10)
        at /Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:528:12
        at next (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:341:14)
        at /Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:351:7
        at next (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:283:14)
        at Immediate._onImmediate (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:319:5)
        at processImmediate [as _immediateCallback] (timers.js:383:17)
    Caused by: Error: boom
        at Context.<anonymous> (/Users/aliu/Sandbox/npm/restify-errors/test/index.js:742:23)
        at callFnAsync (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runnable.js:306:8)
        at Test.Runnable.run (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runnable.js:261:7)
        at Runner.runTest (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:421:10)
        at /Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:528:12
        at next (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:341:14)
        at /Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:351:7
        at next (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:283:14)
        at Immediate._onImmediate (/Users/aliu/Sandbox/npm/restify-errors/node_modules/mocha/lib/runner.js:319:5)
        at processImmediate [as _immediateCallback] (timers.js:383:1
```