### PR TITLE
update to verror 1.7.0. call captureStackTrace manually.

### DIFF
--- a/lib/baseClasses/HttpError.js
+++ b/lib/baseClasses/HttpError.js
@@ -29,10 +29,11 @@ function HttpError() {
     var args = parsed.args;
     var options = parsed.options || {};
 
-    // inherit from WError, call super first before doing anything else!  WError
+    // inherit from WError, call super first before doing anything else! WError
     // will handle calling captureStackTrace, using arguments.callee to
     // eliminate unnecessary stack frames.
     WError.apply(self, args);
+    Error.captureStackTrace(self, HttpError);
 
     /**
      * the error message.

--- a/lib/baseClasses/RestError.js
+++ b/lib/baseClasses/RestError.js
@@ -25,6 +25,7 @@ function RestError() {
 
     // call super
     HttpError.apply(this, args);
+    Error.captureStackTrace(this, RestError);
 
     /**
      * a bit of a misnomer, not really an http code, but rather the name

--- a/lib/httpErrors.js
+++ b/lib/httpErrors.js
@@ -74,6 +74,7 @@ var httpErrors = _.reduce(http.STATUS_CODES, function(acc, desc, code) {
         acc[name] = function() {
             // call super
             HttpError.apply(this, arguments);
+            Error.captureStackTrace(this, acc[name]);
         };
         util.inherits(acc[name], HttpError);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,7 @@ function makeConstructor(name, defaults) {
     var ErrCtor = function() {
         // call super
         RestError.apply(this, arguments);
+        Error.captureStackTrace(this, ErrCtor);
     };
     util.inherits(ErrCtor, RestError);
 

--- a/lib/restErrors.js
+++ b/lib/restErrors.js
@@ -57,6 +57,7 @@ var restErrors = _.reduce(CODES, function(acc, statusCode, errorCode) {
     acc[name] = function() {
         // call super
         RestError.apply(this, arguments);
+        Error.captureStackTrace(this, acc[name]);
     };
     util.inherits(acc[name], RestError);
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "coveralls": "^2.11.4",
     "eslint": "^3.0.1",
     "istanbul": "^0.4.2",
-    "jscs": "^3.0.7",
+    "jscs": "^2.11.0",
     "mkdirp": "^0.5.1",
     "mocha": "^2.3.4",
     "nsp": "^2.2.0",
@@ -53,6 +53,6 @@
   "dependencies": {
     "assert-plus": "^1.0.0",
     "lodash": "^4.2.1",
-    "verror": "^1.6.0"
+    "verror": "^1.7.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -68,7 +68,7 @@ describe('restify-errors node module.', function() {
             var priorErr = new Error('foobar');
             var myErr = new HttpError(priorErr, 'new message');
 
-            assert.equal(myErr.we_cause, priorErr);
+            assert.equal(myErr.cause(), priorErr);
             assert.equal(myErr.name, 'HttpError');
             assert.equal(myErr.message, 'new message');
             assert.isObject(myErr.body);
@@ -81,7 +81,7 @@ describe('restify-errors node module.', function() {
                 message: myErr2Msg
             });
 
-            assert.equal(myErr2.we_cause, priorErr);
+            assert.equal(myErr2.cause(), priorErr);
             assert.equal(myErr2.name, 'HttpError');
             assert.equal(myErr2.message, myErr2Msg);
             assert.isObject(myErr2.body);
@@ -145,7 +145,7 @@ describe('restify-errors node module.', function() {
             var priorErr = new Error('foobar');
             var myErr = new httpErrors.BadGatewayError(priorErr);
 
-            assert.equal(myErr.we_cause, priorErr);
+            assert.equal(myErr.cause(), priorErr);
             assert.equal(myErr.name, 'BadGatewayError');
             assert.equal(myErr.statusCode, 502);
             assert.isObject(myErr.body);
@@ -157,7 +157,7 @@ describe('restify-errors node module.', function() {
                 message: myErr2Msg
             });
 
-            assert.equal(myErr.we_cause, priorErr);
+            assert.equal(myErr.cause(), priorErr);
             assert.equal(myErr2.name, 'BadGatewayError');
             assert.equal(myErr2.statusCode, 502);
             assert.equal(myErr2.message, myErr2Msg);
@@ -218,7 +218,7 @@ describe('restify-errors node module.', function() {
             var priorErr = new Error('foobar');
             var myErr = new RestError(priorErr);
 
-            assert.equal(myErr.we_cause, priorErr);
+            assert.equal(myErr.cause(), priorErr);
             assert.equal(myErr.name, 'RestError');
             assert.equal(myErr.restCode, 'Error');
             assert.equal(myErr.message, '');
@@ -233,7 +233,7 @@ describe('restify-errors node module.', function() {
             };
             var myErr2 = new RestError(priorErr, options);
 
-            assert.equal(myErr2.we_cause, priorErr);
+            assert.equal(myErr2.cause(), priorErr);
             assert.equal(myErr2.name, 'RestError');
             assert.equal(myErr2.restCode, options.restCode);
             assert.equal(myErr2.message, options.message);
@@ -549,7 +549,7 @@ describe('restify-errors node module.', function() {
             assert.isObject(err.body);
             assert.equal(err.body.code, 'Execution');
             assert.equal(err.body.message, 'bad joystick input');
-            assert.equal(err.we_cause, underlyingErr);
+            assert.equal(err.cause(), underlyingErr);
 
             // assert stringification
             assert.equal(JSON.stringify(err), JSON.stringify({
@@ -584,7 +584,7 @@ describe('restify-errors node module.', function() {
             assert.isObject(err.body);
             assert.equal(err.body.code, 'Execution');
             assert.equal(err.body.message, 'bad joystick input');
-            assert.equal(err.we_cause, underlyingErr);
+            assert.equal(err.cause(), underlyingErr);
             assert.equal(err.context.foo, 'bar');
             assert.deepEqual(err.context.baz, [1,2,3]);
 


### PR DESCRIPTION
Fixes stack frames that weren't being elided due to new WError constructor in verror@1.7.0. More details over in joyent/node-verror#39. 