### PR TITLE
New: Expose context

### DIFF
--- a/lib/baseClasses/HttpError.js
+++ b/lib/baseClasses/HttpError.js
@@ -142,10 +142,16 @@ HttpError.prototype.toJSON = function toJSON() {
         message = self.body.message;
     }
 
-    return {
+    var errorObject = {
         code: self.body.code,
         message: message
     };
+
+    if (self.context) {
+        errorObject.context = self.context;
+    }
+
+    return errorObject;
 };
 
 

--- a/lib/baseClasses/HttpError.js
+++ b/lib/baseClasses/HttpError.js
@@ -5,6 +5,7 @@ var util    = require('util');
 
 // external modules
 var WError  = require('verror').WError;
+var _  = require('lodash');
 
 // internal files
 var helpers = require('./../helpers');
@@ -147,7 +148,7 @@ HttpError.prototype.toJSON = function toJSON() {
         message: message
     };
 
-    if (self.context) {
+    if (!_.isEmpty(self.context)) {
         errorObject.context = self.context;
     }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -66,6 +66,7 @@ function parseVariadicArgs(ctorArgs, werrorSuper) {
             assert.optionalObject(options, 'options');
             assert.optionalString(options.message, 'options.message');
             assert.optionalNumber(options.statusCode, 'options.statusCode');
+            assert.optionalObject(options.context, 'options.context');
         }
         // 3
         // otherwise, pass through to WError

--- a/test/index.js
+++ b/test/index.js
@@ -596,7 +596,11 @@ describe('restify-errors node module.', function() {
             var expectedJSON = {
                 code: 'Execution',
                 message: 'bad joystick input; ' +
-                         'caused by Error: underlying error!'
+                         'caused by Error: underlying error!',
+                context: {
+                    foo: 'bar',
+                    baz: [1,2,3]
+                }
             };
             assert.equal(JSON.stringify(err), JSON.stringify(expectedJSON));
             assert.equal(err.toString(), err.name + ': ' + expectedJSON.message);


### PR DESCRIPTION
If `context` is a non empty object, expose it in`toJSON`.

After inspecting the code I found the best solution would be to include `context`, in the response. Internally the module does not place sensitive information on `context`. 

On second thought, this could leak sensitive information in applications relying on `context` being excluded in response. They might utilise this for internal logging. In this case, logger should either introduce a breaking change and bump major version, or introduce an extra option `exposeContext` with  default value of `false`.

fixes https://github.com/restify/errors/issues/80
ping @DonutEspresso @ltvolks @maoueh