### PR TITLE
fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ methods.
 
 **Returns:** {void}
 
-### makeErrFromCode(name [, args...])
+### makeErrFromCode(statusCode [, args...])
 
 Create an Error object using an http status code. This uses `http` module's
 `STATUS_CODES` to do the status code lookup. Thus, this convenience method


### PR DESCRIPTION
changes the `makeErrFromCode` signature to match the description on [L447](https://github.com/restify/errors/pull/85/files#diff-04c6e90faac2675aa89e2176d2eec7d8L447)