### PR TITLE
Added error context to the json

### DIFF
--- a/lib/baseClasses/HttpError.js
+++ b/lib/baseClasses/HttpError.js
@@ -142,10 +142,17 @@ HttpError.prototype.toJSON = function toJSON() {
         message = self.body.message;
     }
 
-    return {
+    var resp = {
         code: self.body.code,
         message: message
     };
+
+    // Add conext if we have it
+    if (self.context) {
+        resp.context = self.context;
+    }
+
+    return resp;
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -536,7 +536,7 @@ describe('restify-errors node module.', function() {
 
         it('should create custom error instance', function() {
             var underlyingErr = new Error('underlying error!');
-            var err = new restifyErrors.ExecutionError(underlyingErr, 'bad joystick input');
+            var err = new restifyErrors.ExecutionError(underlyingErr, {message: 'bad joystick input', context: {key: 'val'}});
 
             assert.equal(err instanceof restifyErrors.ExecutionError, true);
             assert.equal(err instanceof RestError, true);
@@ -557,7 +557,8 @@ describe('restify-errors node module.', function() {
             var expectedJSON = {
                 code: 'Execution',
                 message: 'bad joystick input; ' +
-                         'caused by Error: underlying error!'
+                         'caused by Error: underlying error!',
+                context: {key: 'val'}
             };
             assert.equal(JSON.stringify(err), JSON.stringify(expectedJSON));
             assert.equal(err.toString(), err.name + ': ' + expectedJSON.message);
@@ -596,7 +597,8 @@ describe('restify-errors node module.', function() {
             var expectedJSON = {
                 code: 'Execution',
                 message: 'bad joystick input; ' +
-                         'caused by Error: underlying error!'
+                         'caused by Error: underlying error!',
+                context: {foo: 'bar', baz: [1,2,3]}
             };
             assert.equal(JSON.stringify(err), JSON.stringify(expectedJSON));
             assert.equal(err.toString(), err.name + ': ' + expectedJSON.message);


### PR DESCRIPTION
We need to return extra metadata with our errors, and the existing functionality explicitly stripped the extra context.  This is similar to the functionality that existed in in restify 4.x (although it was in a different format).  Do you think this is a good addition?

CC: @ghermeto @m5m1th