### PR TITLE
new: serialize raw fields in log serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Caused by: Error: file lookup failed!
     at node.js:814:3
 ```
 
-### Bunyan support
+### Bunyan/Pino support
 
 Since errors created via restify-errors inherit from VError, you'll get out of
 the box support via bunyan's standard serializers. If you are using the
@@ -395,6 +395,52 @@ log.error(multiErr, 'oh noes');
 
 For more information about building rich errors, check out
 [VError](https://github.com/davepacheco/node-verror).
+
+
+#### Customizing the serializer
+
+The serializer can also be customized. The serializer currently supports
+the following options:
+
+* `options.topLevelFields` {Boolean} - if true, serializes all top level fields
+ found on the error object, minus "known" Error/VError fields. This can be
+ useful if errors are created in dependencies that don't use VError or
+ restify-errors to maintain context in an independent object.
+
+For example:
+
+```js
+var bunyan = require('bunyan');
+var restifyErrors = require('restify-errors');
+
+var log = bunyan.createLogger({
+    name: 'myLogger',
+    serializers: restifyErrors.bunyanSerializer.create({
+        topLevelFields: true
+    })
+});
+
+var err = new Error('pull!');
+err.espresso = 'normale';
+
+log.error(err, 'oh noes!');
+```
+
+```sh
+[2018-05-22T01:32:25.164Z] ERROR: myLogger/61085 on laptop: oh noes!
+    Error: pull! (espresso="normale")
+        at Object.<anonymous> (/restify/serializer.js:11:11)
+        at Module._compile (module.js:577:32)
+        at Object.Module._extensions..js (module.js:586:10)
+        at Module.load (module.js:494:32)
+        at tryModuleLoad (module.js:453:12)
+        at Function.Module._load (module.js:445:3)
+        at Module.runMain (module.js:611:10)
+        at run (bootstrap_node.js:387:7)
+        at startup (bootstrap_node.js:153:9)
+```
+
+
 
 
 ### Subclassing Errors

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -13,6 +13,24 @@ try {
     safeJsonStringify = null;
 }
 
+// when looping through arbitrary fields attached to the error object, cross
+// reference them against this known list of fields.
+var KNOWN_FIELDS = [
+    // known verror fields
+    'ase_errors',
+    'jse_shortmsg',
+    'jse_cause',
+    'jse_info',
+    'cause',
+    // known Error fields
+    'message',
+    'name',
+    'toJSON',
+    // known restify-error fields
+    'toString',
+    'body'
+];
+
 
 /**
  * built in bunyan serializer for restify errors. it's more or less the
@@ -103,16 +121,6 @@ function getFullErrorStack(err) {
 function getSerializedContext(err) {
 /* eslint-enable max-len */
 
-    var hasContext = Boolean(err.context && _.keys(err.context).length > 0);
-    var verrorInfo = verror.info(err);
-    // verror.info can return an empty object if it doesn't have any context.
-    var hasVErrorInfo = !_.isEmpty(verrorInfo);
-
-    // if we have neither context or verror info, just return early.
-    if (!hasContext && !hasVErrorInfo) {
-        return '\n';
-    }
-
     /**
      * serialize a POJO into a string of the format:
      *     (key=val, key2=val2)
@@ -144,9 +152,25 @@ function getSerializedContext(err) {
         return out.slice(0, -2);
     }
 
-    var fullInfo = _.assign({}, err.context, verrorInfo);
-    var ret = ' (' + serializeIntoEqualString(fullInfo) + ')\n';
-    return ret;
+    var ret = '';
+
+    // look for error context in 3 places, in ascending order of precedence:
+    // 1) raw fields on the error object that are not known verror or
+    // restify-error fields
+    // 2) restify-error context fields (restify-errors@ <= 5.x)
+    // 3) verror info field
+    var rawFields = _.pickBy(err, function(val, key) {
+        return !_.includes(KNOWN_FIELDS, key);
+    });
+
+    // combine all fields into a pojo, and serialize
+    var allFields = _.assign({}, rawFields, err.context, verror.info(err));
+
+    if (!_.isEmpty(allFields)) {
+        ret = ' (' + serializeIntoEqualString(rawFields) + ')';
+    }
+
+    return ret + '\n';
 }
 
 

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -159,9 +159,7 @@ function getSerializedContext(err) {
     // restify-error fields
     // 2) restify-error context fields (restify-errors@ <= 5.x)
     // 3) verror info field
-    var rawFields = _.pickBy(err, function(val, key) {
-        return !_.includes(KNOWN_FIELDS, key);
-    });
+    var rawFields = _.omit(err, KNOWN_FIELDS);
 
     // combine all fields into a pojo, and serialize
     var allFields = _.assign({}, rawFields, err.context, verror.info(err));

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -1,6 +1,7 @@
 'use strict';
 
 // external modules
+var assert = require('assert-plus');
 var _ = require('lodash');
 var verror = require('verror');
 var safeJsonStringify;
@@ -13,81 +14,65 @@ try {
     safeJsonStringify = null;
 }
 
-// when looping through arbitrary fields attached to the error object, cross
-// reference them against this known list of fields.
-var KNOWN_FIELDS = [
-    // known verror fields
-    'ase_errors',
-    'jse_shortmsg',
-    'jse_cause',
-    'jse_info',
-    'cause',
-    // known Error fields
-    'message',
-    'name',
-    'toJSON',
-    // known restify-error fields
-    'toString',
-    'body'
-];
-
 
 /**
- * built in bunyan serializer for restify errors. it's more or less the
- * standard bunyan serializer with support for the context property.
- * @public
- * @function serializer
- * @param {Object} err an error object
- * @returns {Object} serialized object for bunyan output
+ * @class ErrorSerializer
+ * @param {Object} opts an options object
  */
-function serializer(err) {
+function ErrorSerializer(opts) {
+    assert.object(opts, 'opts');
+    assert.bool(opts.topLevelFields, 'opts.topLevelFields');
 
-    if (!err || !err.stack) {
-        return err;
-    }
+    /**
+     * when true, serialize all top level fields found on the Error object
+     * @type {Bool}
+     */
+    this._serializeTopLevelFields = opts.topLevelFields;
 
-    var multiErr = (err.errors && _.isFunction(err.errors));
-
-    return {
-        message: err.message,
-        name: err.name,
-        stack: (multiErr === true) ?
-            getMultiErrorStack(err) :
-            getFullErrorStack(err),
-        code: err.code,
-        signal: err.signal
-    };
+    /**
+     * find known fields we don't want to serialize
+     * @type {Array}
+     */
+    this._knownFields = this._findKnownFields();
 }
 
 
 /**
  * loop through all errors() in a verror.MultiError and build a stack trace
  * output.
+ * @private
+ * @method _getMultiErrorStack
  * @param {Object} err an error object
  * @returns {String} stack trace string
  */
-function getMultiErrorStack(err) {
+ErrorSerializer.prototype._getMultiErrorStack =
+function _getMultiErrorStack(err) {
 
+    var self = this;
     var out = '';
 
     _.forEach(err.errors(), function(e, idx, errs) {
         out += 'MultiError ' + (idx + 1) + ' of ' + errs.length + ': ';
-        out += getFullErrorStack(e) + '\n';
+        out += self._getFullErrorStack(e) + '\n';
     });
 
     // remove last new line char
     out = out.slice(0, -1);
 
     return out;
-}
+};
 
 
 /**
  * loop through all cause() errors and build a stack trace output
+ * @private
+ * @method _getFullErrorStack
  * @param {Object} err an error object
  * @returns {String} stack trace string
  */
-function getFullErrorStack(err) {
+ErrorSerializer.prototype._getFullErrorStack =
+function _getFullErrorStack(err) {
+    var self = this;
     var e = err;
     var out = '';
     var first = true;
@@ -100,30 +85,35 @@ function getFullErrorStack(err) {
         // parse out first new line of stack trace, append context there.
         var stackString = (e.stack || e.toString()).split('\n');
 
-        out += stackString.shift() + getSerializedContext(e);
+        out += stackString.shift() + self._getSerializedContext(e);
         out += stackString.join('\n');
         e = (typeof e.cause === 'function') ? e.cause() : null;
         first = false;
     } while (e);
 
     return out;
-}
+};
 
 
 /* eslint-disable max-len */
+/* jscs:disable maximumLineLength */
 /**
  * serialize the error context object into a string. borrows liberally from
  * bunyan's serializer:
  * https://github.com/trentm/node-bunyan/blob/6fdc5ff20965b81ab15f8f408fe11917e06306f6/lib/bunyan.js#L865
+ * @private
+ * @method _getSerializedContext
  * @param {Object} err an error object
  * @return {String} serialized context obj
  */
-function getSerializedContext(err) {
+/* jscs:enable maximumLineLength */
 /* eslint-enable max-len */
+ErrorSerializer.prototype._getSerializedContext =
+function _getSerializedContext(err) {
 
     /**
      * serialize a POJO into a string of the format:
-     *     (key=val, key2=val2)
+     *     (key="valString", key2=valInteger, key3={a:valPojo})
      * @param {Object} obj a POJO to serialize
      * @return {String}
      */
@@ -152,6 +142,7 @@ function getSerializedContext(err) {
         return out.slice(0, -2);
     }
 
+    var self = this;
     var ret = '';
 
     // look for error context in 3 places, in ascending order of precedence:
@@ -159,17 +150,77 @@ function getSerializedContext(err) {
     // restify-error fields
     // 2) restify-error context fields (restify-errors@ <= 5.x)
     // 3) verror info field
-    var rawFields = _.omit(err, KNOWN_FIELDS);
+    var topLevelFields = (self._serializeTopLevelFields === true) ?
+        _.omit(err, self._knownFields) :
+        {};
 
     // combine all fields into a pojo, and serialize
-    var allFields = _.assign({}, rawFields, err.context, verror.info(err));
+    var allFields = _.assign({}, topLevelFields, err.context, verror.info(err));
 
     if (!_.isEmpty(allFields)) {
-        ret = ' (' + serializeIntoEqualString(rawFields) + ')';
+        ret = ' (' + serializeIntoEqualString(allFields) + ')';
     }
 
     return ret + '\n';
-}
+};
+
+
+/**
+ * find a list of known error fields that we don't want to serialize. create
+ * verror instances to programatically build that list.
+ * @private
+ * @method _findKnownFields
+ * @return {Array}
+ */
+ErrorSerializer.prototype._findKnownFields = function _findKnownFields() {
+    // when looping through arbitrary fields attached to the error object, cross
+    // reference them against this known list of fields.
+    var fields = [
+        // known Error fields
+        'message',
+        'name',
+        'toJSON',
+        // known restify-error fields
+        'toString',
+        'body'
+    ];
+
+    // make a verror and multierror and find expected fields
+    var verr = new verror.VError();
+    var multiErr = new verror.MultiError([ verr ]);
+    fields.push(_.keys(verr));
+    fields.push(_.keys(multiErr));
+
+    return _(fields).flatten().uniq().value();
+};
+
+
+/**
+ * built in bunyan serializer for restify errors. it's more or less the
+ * standard bunyan serializer with support for the context property.
+ * @private
+ * @method serialize
+ * @param {Object} err an error object
+ * @returns {Object} serialized object for bunyan output
+ */
+ErrorSerializer.prototype.serialize = function serialize(err) {
+    if (!err || !err.stack) {
+        return err;
+    }
+
+    var self = this;
+    var multiErr = (err.errors && _.isFunction(err.errors));
+
+    return {
+        message: err.message,
+        name: err.name,
+        stack: (multiErr === true) ?
+            self._getMultiErrorStack(err) :
+            self._getFullErrorStack(err),
+        code: err.code,
+        signal: err.signal
+    };
+};
 
 
 /**
@@ -196,5 +247,29 @@ function safeCycles() {
 }
 
 
+/**
+ * factory function to create customized serializers.
+ * @public
+ * @param {Object} options an options object
+ * @return {Function} serializer function
+ */
+function create(options) {
+    assert.optionalObject(options, 'options');
 
-module.exports = serializer;
+    var opts = _.assign({
+        topLevelFields: false
+    }, options);
+
+    var serializer = new ErrorSerializer(opts);
+    serializer.serialize = serializer.serialize.bind(serializer);
+    return serializer.serialize;
+}
+
+
+
+// we should be exporting the factory, but to refrain from making it a breaking
+// change, let's attach the factory to the existing function export.
+var defaultSerializer = create();
+defaultSerializer.create = create;
+
+module.exports = defaultSerializer;

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -253,7 +253,7 @@ function safeCycles() {
  * @param {Object} options an options object
  * @return {Function} serializer function
  */
-function create(options) {
+function factory(options) {
     assert.optionalObject(options, 'options');
 
     var opts = _.assign({
@@ -261,15 +261,24 @@ function create(options) {
     }, options);
 
     var serializer = new ErrorSerializer(opts);
+    // rebind the serialize function since this will be lost when we export it
+    // as a POJO
     serializer.serialize = serializer.serialize.bind(serializer);
-    return serializer.serialize;
+
+    return serializer;
 }
 
 
+// we should be exporting this create function, but to refrain from making it a
+// breaking change, let's attach the create to the existing function export. we
+// can make the change in next major version.
+var defaultSerializer = factory();
+defaultSerializer.serialize.create = function create(opts) {
+    var serializer = factory(opts);
+    return {
+        err: serializer.serialize
+    };
+};
 
-// we should be exporting the factory, but to refrain from making it a breaking
-// change, let's attach the factory to the existing function export.
-var defaultSerializer = create();
-defaultSerializer.create = create;
 
-module.exports = defaultSerializer;
+module.exports = defaultSerializer.serialize;

--- a/test/index.js
+++ b/test/index.js
@@ -828,24 +828,6 @@ describe('restify-errors node module.', function() {
             done();
         });
 
-        it('should serialize a restify-error Error', function(done) {
-
-            var err = new Error('boom');
-            var myErr = new restifyErrors.InternalServerError({
-                cause: err,
-                context: {
-                    foo: 'bar',
-                    baz: 1
-                }
-            }, 'ISE');
-
-            assert.doesNotThrow(function() {
-                logger.error(myErr, 'wrapped error');
-            });
-
-            done();
-        });
-
         it('should ignore serializer', function(done) {
 
             // pass an error object without stack
@@ -921,6 +903,30 @@ describe('restify-errors node module.', function() {
 
             assert.doesNotThrow(function() {
                 logger.error(multiError, 'MultiError');
+            });
+        });
+
+        it('should serialize arbitrary fields on Error', function() {
+
+            var err1 = new Error('pull!');
+            err1.espresso = 'normale';
+
+            assert.doesNotThrow(function() {
+                logger.error(err1, 'normal error with fields');
+            });
+        });
+
+        it('should not serialize arbitrary fields on VError', function() {
+            var err1 = new verror.VError({
+                name: 'VErrorInfo',
+                info: {
+                    espresso: 'ristretto'
+                }
+            }, 'pull!');
+            err1.espresso = 'lungo';
+
+            assert.doesNotThrow(function() {
+                logger.error(err1, 'verror with fields');
             });
         });
     });


### PR DESCRIPTION
This will now serialize raw fields on the Error object (statusCode, code, etc.). This includes any arbitrary fields that other libraries may attach onto the Error object. This is particularly useful for isomorphic libraries that can't/won't take on a VError dependency.