### PR TITLE
fix: remove duplication of serialized Error properties

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -144,20 +144,8 @@ function getSerializedContext(err) {
         return out.slice(0, -2);
     }
 
-    var ret = ' (';
-
-    // construct context info
-    if (hasContext === true) {
-        ret += serializeIntoEqualString(err.context);
-    }
-
-    // construct VError info object
-    if (hasVErrorInfo === true) {
-        ret += serializeIntoEqualString(verrorInfo);
-    }
-
-    ret += ')\n';
-
+    var fullInfo = _.assign({}, err.context, verrorInfo);
+    var ret = ' (' + serializeIntoEqualString(fullInfo) + ')\n';
     return ret;
 }
 


### PR DESCRIPTION
In 6.x restify-errors legacy `context` option was implemented using verror info. This caused duplication of properties as we serialized both independently:

```
MultiError 2 of 3: InternalServerError: ISE (foo="bar", baz=1foo="bar", baz=1)
```

```
MultiError 2 of 3: InternalServerError: ISE (foo="bar", baz=1)
```

This PR merges the two buckets into a single bucket (as verror does) before serialization.