### PR TITLE
fix: topLevelFields should not serialize known VError proto fields

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -189,7 +189,9 @@ ErrorSerializer.prototype._findKnownFields = function _findKnownFields() {
     var verr = new verror.VError();
     var multiErr = new verror.MultiError([ verr ]);
     fields.push(_.keys(verr));
+    fields.push(_.keys(Object.getPrototypeOf(verr)));
     fields.push(_.keys(multiErr));
+    fields.push(_.keys(Object.getPrototypeOf(multiErr)));
 
     return _(fields).flatten().uniq().value();
 };

--- a/test/index.js
+++ b/test/index.js
@@ -965,5 +965,23 @@ describe('restify-errors node module.', function() {
             var serializedErr = serializer.err(err1, 'oh noes!');
             assert.notInclude(serializedErr.stack, 'espresso=normale');
         });
+
+        it('should not serialize known fields on VError', function() {
+            var serializer = restifyErrors.bunyanSerializer.create({
+                topLevelFields: true
+            });
+            var err1 = new verror.VError({
+                name: 'VErrorInfo',
+                info: {
+                    espresso: 'ristretto'
+                }
+            }, 'pull!');
+            err1.espresso = 'lungo';
+
+            logger.child({ serializers: serializer }).error(err1);
+
+            var serializedErr = serializer.err(err1, 'oh noes!');
+            assert.notInclude(serializedErr.stack, 'cause=undefined');
+        });
     });
 });


### PR DESCRIPTION
This was causing Verror's `cause` function to get serialized in the stack trace when `topLevelFields: true` was set:

```sh
[2018-06-19T01:53:06.504Z] ERROR: unit-test/64989 on nfml-aliu: pull!
    VErrorInfo: pull! (espresso="ristretto", cause=undefined)
        at Context.<anonymous> (/Users/aliu/Sandbox/restify-errors/test/index.js:973:24)
        at callFn (/Users/aliu/Sandbox/restify-errors/node_modules/mocha/lib/runnable.js:360:21)
        at Test.Runnable.run (/Users/aliu/Sandbox/restify-errors/node_modules/mocha/lib/runnable.js:352:7)
```