### PR TITLE
new: add option to omit fields from serializer

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -22,6 +22,7 @@ try {
 function ErrorSerializer(opts) {
     assert.object(opts, 'opts');
     assert.bool(opts.topLevelFields, 'opts.topLevelFields');
+    assert.array(opts.omitFields, 'opts.omitFields');
 
     /**
      * when true, serialize all top level fields found on the Error object
@@ -33,7 +34,7 @@ function ErrorSerializer(opts) {
      * find known fields we don't want to serialize
      * @type {Array}
      */
-    this._knownFields = this._findKnownFields();
+    this._knownFields = this._findKnownFields().concat(opts.omitFields);
 }
 
 
@@ -259,7 +260,8 @@ function factory(options) {
     assert.optionalObject(options, 'options');
 
     var opts = _.assign({
-        topLevelFields: false
+        topLevelFields: false,
+        omitFields: []
     }, options);
 
     var serializer = new ErrorSerializer(opts);

--- a/test/index.js
+++ b/test/index.js
@@ -983,5 +983,19 @@ describe('restify-errors node module.', function() {
             var serializedErr = serializer.err(err1, 'oh noes!');
             assert.notInclude(serializedErr.stack, 'cause=undefined');
         });
+
+        it('should not serialize omitted fields', function() {
+            var serializer = restifyErrors.bunyanSerializer.create({
+                topLevelFields: true,
+                omitFields: [ 'foo' ]
+            });
+            var err1 = new Error('bar');
+            err1.foo = 'baz';
+
+            logger.child({ serializers: serializer }).error(err1);
+
+            var serializedErr = serializer.err(err1, 'oh noes!');
+            assert.notInclude(serializedErr.stack, 'foo="baz"');
+        });
     });
 });


### PR DESCRIPTION
Add an option to omit specific top-level fields from the serializer.