### PR TITLE
breaking: omit node domains from serializer

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -4,6 +4,7 @@
 var assert = require('assert-plus');
 var _ = require('lodash');
 var verror = require('verror');
+var domain = require('domain');
 var safeJsonStringify;
 
 // try to require optional dependency
@@ -153,6 +154,10 @@ function _getSerializedContext(err) {
     var topLevelFields = (self._serializeTopLevelFields === true) ?
         _.omit(err, self._knownFields) :
         {};
+
+    if (topLevelFields.domain instanceof domain.Domain) {
+        topLevelFields = _.omit(topLevelFields, [ 'domain' ]);
+    }
 
     // combine all fields into a pojo, and serialize
     var allFields = _.assign({}, topLevelFields, err.context, verror.info(err));


### PR DESCRIPTION
Omit domain fields from serializer when using node domains

FYI @misterdjules @DonutEspresso 