### PR TITLE
chore(lib): don't require domain by default

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -2,12 +2,16 @@
 
 // external modules
 var assert = require('assert-plus');
+var EventEmitter = require('events');
 var _ = require('lodash');
 var nerror = require('@netflix/nerror');
-var domain = require('domain');
 var MultiError = nerror.MultiError;
 var VError = nerror.VError;
 var safeJsonStringify;
+
+// We load the domain module lazily to avoid performance regression on Node.js
+// v12.
+var domain;
 
 // try to require optional dependency
 try {
@@ -157,8 +161,17 @@ function _getSerializedContext(err) {
         _.omit(err, self._knownFields) :
         {};
 
-    if (topLevelFields.domain instanceof domain.Domain) {
-        topLevelFields = _.omit(topLevelFields, [ 'domain' ]);
+    // We don't want to load domains just to check if topLevelFields.domain is
+    // a Domain instance, so first we make sure domains are already loaded.
+    if (EventEmitter.usingDomains) {
+        if (!domain) {
+            // eslint-disable-next-line global-require
+            domain = require('domain');
+        }
+
+        if (topLevelFields.domain instanceof domain.Domain) {
+            topLevelFields = _.omit(topLevelFields, [ 'domain' ]);
+        }
     }
 
     // combine all fields into a pojo, and serialize

--- a/test/index.js
+++ b/test/index.js
@@ -5,7 +5,6 @@
 
 // core modules
 var http = require('http');
-var domain = require('domain');
 
 // userland
 var assert = require('chai').assert;
@@ -1002,6 +1001,8 @@ describe('restify-errors node module.', function() {
 
         // eslint-disable-next-line max-len
         it('should not serialize domain when using node domains', function(done) {
+            // eslint-disable-next-line global-require
+            var domain = require('domain');
             var dom = domain.create();
             dom.on('error', function(err1) {
                 var serializer = restifyErrors.bunyanSerializer.create({


### PR DESCRIPTION
Domains have an unwanted overhead on Node.js v12. The overhead is
observable just by requiring `domain`. To prevent that, we postpone
requiring `domain` until we are sure it's necessary (in which case it
was already required somewhere else).