### PR TITLE
fix!: use spec Error.cause property instead of legacy cause() function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,23 +9,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20, 22]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Setup Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install
-        run: npm ci
-      - name: Test / Lint / Codestyle
-        run: make all
-  test-optional:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
         node-version: [24, 26]
     steps:
       - name: Checkout
@@ -36,7 +19,5 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: npm ci
-        continue-on-error: true
       - name: Test / Lint / Codestyle
         run: make all
-        continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [24]
+        node-version: [24, 26]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Change log
 
+## 9.0.0-rc.0
+
+- BREAKING: upgrade to `@netflix/nerror@2.0.0-rc.0`, which drops the legacy
+  `.cause()` function in favor of the spec `Error.prototype.cause` property.
+  `lib/serializer.js` and `lib/baseClasses/HttpError.js` now read `err.cause`
+  as a property instead of invoking it as a function.
+
 ## 7.0.0
 
 - BREAKING: omit node domains from serializer

--- a/lib/baseClasses/HttpError.js
+++ b/lib/baseClasses/HttpError.js
@@ -149,8 +149,8 @@ HttpError.prototype.toJSON = function toJSON() {
     var message = '';
 
     // if we have a cause, get the full VError toString() without the current
-    // error name. verbose check, self.cause can exist but returns undefined
-    if (self.cause && typeof self.cause === 'function' && self.cause()) {
+    // error name.
+    if (self.cause) {
         var fullString = self.toString();
         message = fullString.substr(fullString.indexOf(' ') + 1);
     } else {
@@ -159,8 +159,7 @@ HttpError.prototype.toJSON = function toJSON() {
 
     return {
         code: self.body.code,
-        message: message,
-        cause: self.cause
+        message: message
     };
 };
 

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -71,7 +71,7 @@ function _getMultiErrorStack(err) {
 
 
 /**
- * loop through all cause() errors and build a stack trace output
+ * loop through all cause errors and build a stack trace output
  * @private
  * @method _getFullErrorStack
  * @param {Object} err an error object
@@ -94,7 +94,7 @@ function _getFullErrorStack(err) {
 
         out += stackString.shift() + self._getSerializedContext(e);
         out += stackString.join('\n');
-        e = (typeof e.cause === 'function') ? e.cause() : null;
+        e = e.cause || null;
         first = false;
     } while (e);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "restify-errors",
-  "version": "8.1.0",
+  "version": "9.0.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "restify-errors",
-      "version": "8.1.0",
+      "version": "9.0.0-rc.0",
       "license": "MIT",
       "dependencies": {
-        "@netflix/nerror": "^1.1.3",
+        "@netflix/nerror": "^2.0.0",
         "assert-plus": "^1.0.0",
         "lodash": "^4.17.21"
       },
@@ -21,8 +21,11 @@
         "mkdirp": "^0.5.1",
         "mocha": "^6.2.2",
         "nyc": "^14.1.1",
-        "restify": "^11.1.0",
-        "restify-clients": "^4.2.0"
+        "restify": "^12.0.0",
+        "restify-clients": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=24"
       },
       "optionalDependencies": {
         "safe-json-stringify": "^1.2.0"
@@ -194,14 +197,17 @@
       }
     },
     "node_modules/@netflix/nerror": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@netflix/nerror/-/nerror-1.1.3.tgz",
-      "integrity": "sha512-b+MGNyP9/LXkapreJzNUzcvuzZslj/RGgdVVJ16P2wSlYatfLycPObImqVJSmNAdyeShvNeM/pl3sVZsObFueg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@netflix/nerror/-/nerror-2.0.0.tgz",
+      "integrity": "sha512-78vO+n0ONT+WIpaaaKYycUin/GeKXLWKdRq5l1NkbPsPf6mtZwVW3msqIwKYeJCMvoJHtE5u68vRZb89jRi7LQ==",
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "extsprintf": "^1.4.0",
         "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/abort-controller": {
@@ -1180,24 +1186,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -1277,9 +1265,9 @@
       "license": "MIT"
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1871,18 +1859,18 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.7.0.tgz",
-      "integrity": "sha512-+SrHpvQ52Q6W9f3wJoJBbAQULJuNEEQwBvlvYwACDhBTLOTMiQ0HYWh4+vC3OivGP2ENcTI1oKlFA2OepJNjhQ==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.9.0.tgz",
+      "integrity": "sha512-sJsgZ1sQH2UDuowPuMKg8az7Qc8F0jnj+SKkFWU/+T0xcFlgV5skgXOGUqmQzOdmW6ALA7AhJINWx3qFBkbLHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-querystring": "^1.0.0",
-        "safe-regex2": "^2.0.0"
+        "safe-regex2": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/find-up": {
@@ -2019,13 +2007,13 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -2278,13 +2266,6 @@
         "node": ">=4.x"
       }
     },
-    "node_modules/handle-thing": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
-      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -2434,59 +2415,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/hpack.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
-      }
-    },
-    "node_modules/hpack.js/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/hpack.js/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/hpack.js/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/hpack.js/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2494,28 +2422,25 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/http-deceiver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-signature": {
@@ -3442,13 +3367,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/keep-alive-agent": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz",
-      "integrity": "sha512-fF6aj9/XFwJiE/4zihw/ZdXg+KeyU4nFvmutF+PkAVadSGqP298+Zm6IzWFzgeDBgvLk3o8boBxNtd1g5Kdjfg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lcov-parse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
@@ -3658,13 +3576,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -4103,13 +4014,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -4497,13 +4401,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/process-warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
@@ -4569,13 +4466,17 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/read-pkg": {
@@ -4784,9 +4685,9 @@
       }
     },
     "node_modules/restify": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/restify/-/restify-11.1.0.tgz",
-      "integrity": "sha512-ng7uBlj4wpIpshhAjNNSd6JG5Eg32+zgync2gG8OlF4e2xzIflZo54GJ/qLs765OtQaVU+uJPcNOL5Atm2F/dg==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/restify/-/restify-12.0.0.tgz",
+      "integrity": "sha512-phWRX0ca9sSulM6SJ2SxnPze7gmkm2ePLNd6cuo9loM1UfARu+ZhcNNCKldEal/R3virVcl6Anp1XyPNVVCptQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4794,7 +4695,7 @@
         "csv": "^6.2.2",
         "escape-regexp-component": "^1.0.2",
         "ewma": "^2.0.1",
-        "find-my-way": "^7.2.0",
+        "find-my-way": "^9.6.0",
         "formidable": "^1.2.1",
         "http-signature": "^1.3.6",
         "lodash": "^4.17.11",
@@ -4804,28 +4705,26 @@
         "once": "^1.4.0",
         "pidusage": "^3.0.2",
         "pino": "^8.7.0",
-        "qs": "^6.7.0",
+        "qs": "^6.15.2",
         "restify-errors": "^8.0.2",
         "semver": "^7.3.8",
-        "send": "^0.18.0",
-        "spdy": "^4.0.0",
-        "uuid": "^9.0.0",
+        "send": "^1.2.1",
         "vasync": "^2.2.0"
       },
       "bin": {
         "report-latency": "bin/report-latency"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "dtrace-provider": "~0.8"
       }
     },
     "node_modules/restify-clients": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/restify-clients/-/restify-clients-4.2.0.tgz",
-      "integrity": "sha512-6Dnmx///LlHXq7QUnDoL54aeTuGEnW/hb0DQ3djm9Q180LrXHwdxU/Hz6hHHnGdCjIQvZI7D0lpQVbq2PZY0Gw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/restify-clients/-/restify-clients-6.0.0.tgz",
+      "integrity": "sha512-coR2LfPMhzUERuoPu1EwkdG0u51r3udQkPTLtKc1OW+a1HbLNhq/JEjHXNxvSsPLuiDVq1IiVMCYe0b2+iq7sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4833,16 +4732,16 @@
         "backoff": "^2.5.0",
         "bunyan": "^1.8.12",
         "fast-safe-stringify": "^2.0.6",
-        "keep-alive-agent": "0.0.1",
         "lodash": "^4.17.15",
         "lru-cache": "^5.1.1",
         "mime": "^2.4.0",
         "once": "^1.4.0",
         "qs": "^6.6.0",
         "restify-errors": "^8.0.2",
-        "semver": "^5.6.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "dtrace-provider": "^0.8.7"
@@ -4886,16 +4785,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/restify-clients/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/restify-clients/node_modules/yallist": {
@@ -4991,21 +4880,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/restify/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -5021,13 +4895,13 @@
       }
     },
     "node_modules/ret": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
-      "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=10"
       }
     },
     "node_modules/rimraf": {
@@ -5151,13 +5025,26 @@
       }
     },
     "node_modules/safe-regex2": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-2.0.0.tgz",
-      "integrity": "sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "ret": "~0.2.0"
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
       }
     },
     "node_modules/safe-stable-stringify": {
@@ -5177,13 +5064,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/select-hose": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -5195,58 +5075,57 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/send/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/send/node_modules/debug/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/send/node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-blocking": {
@@ -5514,53 +5393,6 @@
       "dev": true,
       "license": "CC0-1.0"
     },
-    "node_modules/spdy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
-      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "handle-thing": "^2.0.0",
-        "http-deceiver": "^1.2.7",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/spdy-transport": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
-      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.2",
-        "readable-stream": "^3.0.6",
-        "wbuf": "^1.7.3"
-      }
-    },
-    "node_modules/spdy-transport/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -5605,9 +5437,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6097,13 +5929,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -6159,16 +5984,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      }
-    },
-    "node_modules/wbuf": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimalistic-assert": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
   "scripts": {
     "test": "make test"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "devDependencies": {
     "bunyan": "^1.8.12",
     "chai": "^4.2.0",
@@ -45,17 +48,21 @@
     "mkdirp": "^0.5.1",
     "mocha": "^6.2.2",
     "nyc": "^14.1.1",
-    "restify": "^11.1.0",
-    "restify-clients": "^4.2.0"
+    "restify": "^12.0.0",
+    "restify-clients": "^6.0.0"
   },
   "optionalDependencies": {
     "safe-json-stringify": "^1.2.0"
   },
   "overrides": {
-    "@netflix/nerror": "^2.0.0-rc.0"
+    "restify-clients": {
+      "restify-errors": {
+        "@netflix/nerror": "^2.0.0"
+      }
+    }
   },
   "dependencies": {
-    "@netflix/nerror": "^2.0.0-rc.0",
+    "@netflix/nerror": "^2.0.0",
     "assert-plus": "^1.0.0",
     "lodash": "^4.17.21"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-errors",
-  "version": "8.1.0",
+  "version": "9.0.0-rc.0",
   "main": "lib/index.js",
   "description": "Collection of Error objects shared across restify components.",
   "homepage": "http://www.restify.com",
@@ -51,8 +51,11 @@
   "optionalDependencies": {
     "safe-json-stringify": "^1.2.0"
   },
+  "overrides": {
+    "@netflix/nerror": "^2.0.0-rc.0"
+  },
   "dependencies": {
-    "@netflix/nerror": "^1.1.3",
+    "@netflix/nerror": "^2.0.0-rc.0",
     "assert-plus": "^1.0.0",
     "lodash": "^4.17.21"
   }

--- a/test/index.js
+++ b/test/index.js
@@ -76,7 +76,7 @@ describe('restify-errors node module.', function() {
             var priorErr = new Error('foobar');
             var myErr = new HttpError(priorErr, 'new message');
 
-            assert.equal(myErr.cause(), priorErr);
+            assert.equal(myErr.cause, priorErr);
             assert.equal(myErr.name, 'HttpError');
             assert.equal(myErr.message, 'new message');
             assert.isObject(myErr.body);
@@ -89,7 +89,7 @@ describe('restify-errors node module.', function() {
                 cause: priorErr
             }, myErr2Msg);
 
-            assert.equal(myErr2.cause(), priorErr);
+            assert.equal(myErr2.cause, priorErr);
             assert.equal(myErr2.name, 'HttpError');
             assert.equal(myErr2.message, myErr2Msg);
             assert.isObject(myErr2.body);
@@ -193,7 +193,7 @@ describe('restify-errors node module.', function() {
             var priorErr = new Error('foobar');
             var myErr = new httpErrors.BadGatewayError(priorErr);
 
-            assert.equal(myErr.cause(), priorErr);
+            assert.equal(myErr.cause, priorErr);
             assert.equal(myErr.name, 'BadGatewayError');
             assert.equal(myErr.statusCode, 502);
             assert.isObject(myErr.body);
@@ -205,7 +205,7 @@ describe('restify-errors node module.', function() {
                 cause: priorErr
             }, myErr2Msg);
 
-            assert.equal(myErr.cause(), priorErr);
+            assert.equal(myErr.cause, priorErr);
             assert.equal(myErr2.name, 'BadGatewayError');
             assert.equal(myErr2.statusCode, 502);
             assert.equal(myErr2.message, myErr2Msg);
@@ -272,7 +272,7 @@ describe('restify-errors node module.', function() {
             var priorErr = new Error('foobar');
             var myErr = new RestError(priorErr);
 
-            assert.equal(myErr.cause(), priorErr);
+            assert.equal(myErr.cause, priorErr);
             assert.equal(myErr.name, 'RestError');
             assert.equal(myErr.restCode, 'Error');
             assert.equal(myErr.message, '');
@@ -288,7 +288,7 @@ describe('restify-errors node module.', function() {
             };
             var myErr2 = new RestError(options, errMsg);
 
-            assert.equal(myErr2.cause(), priorErr);
+            assert.equal(myErr2.cause, priorErr);
             assert.equal(myErr2.name, 'RestError');
             assert.equal(myErr2.restCode, options.restCode);
             assert.equal(myErr2.message, errMsg);
@@ -605,7 +605,7 @@ describe('restify-errors node module.', function() {
             assert.isObject(err.body);
             assert.equal(err.body.code, 'Execution');
             assert.equal(err.body.message, 'bad joystick input');
-            assert.equal(err.cause(), underlyingErr);
+            assert.equal(err.cause, underlyingErr);
 
             // assert stringification
             var expectedJSON = {
@@ -646,7 +646,7 @@ describe('restify-errors node module.', function() {
             assert.isObject(err.body);
             assert.equal(err.body.code, 'Execution');
             assert.equal(err.body.message, 'bad joystick input');
-            assert.equal(err.cause(), underlyingErr);
+            assert.equal(err.cause, underlyingErr);
             assert.deepEqual(restifyErrors.info(err), {
                 foo: 'bar',
                 baz: [ 1, 2, 3 ]


### PR DESCRIPTION
@netflix/nerror@2.0.0-rc.0 replaces the non-standard cause() method with the native Error.cause property. Update HttpError.toJSON() and the serializer's cause-chain walk accordingly, and fix a latent bug where toJSON() was serializing the cause function reference itself rather than a value.

As a follow-up, the `devDependencies` on `restify` and `restify-clients` should be updated after the next major release of those libraries. Until then, `nerror`'s tests will fail on node 24 and node 26.