### PR TITLE
ci: dipatch npm-publish from release-please

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,17 +1,21 @@
 name: npm-publish
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Release tag to publish, for example v1.0.0. Leave empty to run
+          validation only (dry run).
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  # tag_name grouping - queues actual releases for the same tag
-  # run_id - fallback value required for group as tag_name might not always be present (manual triggers)
-  group: npm-publish-${{ github.event.release.tag_name || github.run_id }}
+  # tag grouping - queues repeat publishes of the same release
+  # run_id - fallback for validation-only runs, which have no tag
+  group: npm-publish-${{ inputs.tag || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -21,21 +25,20 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name || github.ref }}
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 26.x
 
       - name: verify release version
-        if: github.event_name == 'release'
+        if: inputs.tag != ''
         run: |
           pkg_name=$(jq -r .name package.json)
           pkg_version=$(jq -r .version package.json)
-          tag_version="${GITHUB_EVENT_RELEASE_TAG_NAME#v}"
-          if [ "$pkg_version" != "$tag_version" ]; then
-            echo "package.json version ($pkg_version) does not match release tag ($tag_version)"
+          if [ "v${pkg_version}" != "$RELEASE_TAG" ]; then
+            echo "package.json version ($pkg_version) does not match release tag ($RELEASE_TAG)"
             exit 1
           fi
           if npm view "${pkg_name}@${pkg_version}" version >/dev/null 2>&1; then
@@ -43,7 +46,7 @@ jobs:
             exit 1
           fi
         env:
-          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
 
       - name: validate publish package contents
         run: |
@@ -55,7 +58,7 @@ jobs:
   publish:
     name: publish
     needs: validate
-    if: github.event_name == 'release'
+    if: inputs.tag != ''
     runs-on: ubuntu-latest
     environment: Publish
     permissions:
@@ -64,12 +67,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag }}
           persist-credentials: false
 
       - uses: actions/setup-node@v7
         with:
-          node-version: 22.x
+          node-version: 26.x
           registry-url: https://registry.npmjs.org
 
       - name: publish to npm

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,10 +7,25 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  # Releases created with GITHUB_TOKEN cannot trigger other workflows, so
+  # npm-publish is dispatched explicitly below. workflow_dispatch is one of the
+  # few events that always creates a run, even from GITHUB_TOKEN.
+  actions: write
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v5
+        id: release
         with:
           release-type: node
+
+      # releases_created is only true on the run that tagged a release, which is
+      # the run triggered by merging the release PR.
+      - name: trigger npm-publish
+        if: steps.release.outputs.releases_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: gh workflow run npm-publish.yml --ref "$GITHUB_REF_NAME" -f tag="$TAG"

--- a/README.md
+++ b/README.md
@@ -543,6 +543,15 @@ If you have style errors, you can auto fix whitespace issues by running:
 make codestyle-fix
 ```
 
+### Releasing
+
+Releases are automated with [release-please](https://github.com/googleapis/release-please#readme):
+
+1. Merge conventional-commit-style PRs (`fix:`, `feat:`, etc.) into `master`.
+2. `release-please` opens or updates a Release PR with the version bump and changelog.
+3. Review and merge the Release PR when ready to ship.
+4. `release-please` tags the release and dispatches the `npm-publish` workflow, which validates and publishes the package to npm.
+
 ## License
 
 Copyright (c) 2018 Alex Liu


### PR DESCRIPTION
Releases created with GITHUB_TOKEN (via release-please) don't trigger other workflows, so npm-publish would never have worked. [More details here](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs)

Switch npm-publish to workflow_dispatch with a tag input, and have release-please explicitly dispatch it via gh workflow run once a release is tagged.