### PR TITLE
chore: lower Node engines floor back to >=22.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [24, 26]
+        node-version: [22, 24, 26]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "restify-clients": "^6.0.0"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=22.0.0"
       },
       "optionalDependencies": {
         "safe-json-stringify": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "make test"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=22.0.0"
   },
   "devDependencies": {
     "bunyan": "^1.8.12",


### PR DESCRIPTION
Aligns with restify's own >=22.0.0 floor. Verified 56/56 tests pass on Node 22.