### PR TITLE
fix(deps): bump @netflix/nerror to ^2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "9.0.0",
       "license": "MIT",
       "dependencies": {
-        "@netflix/nerror": "^2.0.0",
+        "@netflix/nerror": "^2.0.1",
         "assert-plus": "^1.0.0",
         "lodash": "^4.17.21"
       },
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@netflix/nerror": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@netflix/nerror/-/nerror-2.0.0.tgz",
-      "integrity": "sha512-78vO+n0ONT+WIpaaaKYycUin/GeKXLWKdRq5l1NkbPsPf6mtZwVW3msqIwKYeJCMvoJHtE5u68vRZb89jRi7LQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@netflix/nerror/-/nerror-2.0.1.tgz",
+      "integrity": "sha512-YzrgOzMVc3IHq0tQoZuUuFKCNIdyvhySA++EaGlBvIBRAVelEGwdLbYX1v6jv7gGOX1bm8EBpBt22Ywr+tFckw==",
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
@@ -207,7 +207,7 @@
         "lodash": "^4.17.15"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/abort-controller": {

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
   "overrides": {
     "restify-clients": {
       "restify-errors": {
-        "@netflix/nerror": "^2.0.0"
+        "@netflix/nerror": "^2.0.1"
       }
     }
   },
   "dependencies": {
-    "@netflix/nerror": "^2.0.0",
+    "@netflix/nerror": "^2.0.1",
     "assert-plus": "^1.0.0",
     "lodash": "^4.17.21"
   }


### PR DESCRIPTION
nerror@2.0.1 lowers its own Node engines floor from >=24 to \>=22.0.0, matching restify-errors' own floor.